### PR TITLE
fix chainspec for wococo

### DIFF
--- a/wococo/relaychain/chainspec.json
+++ b/wococo/relaychain/chainspec.json
@@ -6,7 +6,7 @@
     "/dns/wococo-bootnode-0.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWSZc8vozoXUmZvFCZ2J1aBCxhGEk7ydzw7eUG7W27r47Y",
     "/dns/wococo-bootnode-1.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWRVNuDBYrtiFc8XCfXsJJV9qMuof3NDmipq57KHmRgvdZ",
     "/dns/wococo-bootnode-2.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWRu1vcQBfTZMCdQAvDn2vAo3fPLdkgCUQz6akND7ZfTca",
-    "/dns/wococo-bootnode-3.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWPKNDwgu1NtV85QQfNbcMPqRHBtu2bRKYWfBqFXhuNtdw"
+    "/dns/wococo-bootnode-3.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWQ7f59Xrn4zp6TEutcVmUYjhr4vXrigo7FJRvnoLRsqdw"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
Signed-off-by: BulatSaif <bulat@parity.io>

This MR will fix error:
```
ERROR tokio-runtime-worker sc_network::service: 💔 The bootnode you want to connect to at `/dns/wococo-bootnode-3.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWPKNDwgu1NtV85QQfNbcMPqRHBtu2bRKYWfBqFXhuNtdw` provided a different peer ID `12D3KooWQ7f59Xrn4zp6TEutcVmUYjhr4vXrigo7FJRvnoLRsqdw` than the one you expect `12D3KooWPKNDwgu1NtV85QQfNbcMPqRHBtu2bRKYWfBqFXhuNtdw`.
```