### PR TITLE
Fix id in rockmine chainspec 

### DIFF
--- a/rococo/parachain/rockmine/chainspec.json
+++ b/rococo/parachain/rockmine/chainspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Rockmine",
-  "id": "rococo-rockmine",
+  "id": "statemine-rococo",
   "chainType": "Live",
   "bootNodes": [
     "/dns/rococo-rockmine-collator-0.parity-testnet.parity.io/tcp/30334/p2p/12D3KooWRrZMndHAopzao34uGsN7srjS3gh9nAjTGKLSyJeU31Lg",


### PR DESCRIPTION
The id has to be prefixed with 'statemine otherwise the node won't choose the right runtime.
This is caused by [this code](https://github.com/paritytech/cumulus/blob/master/polkadot-parachain/src/command.rs#L95)