### PR TITLE
temporarily mark block #7829923 as bad

### DIFF
--- a/rococo/hack/chainspec.json
+++ b/rococo/hack/chainspec.json
@@ -21,7 +21,9 @@
     "tokenSymbol": "ROC"
   },
   "forkBlocks": null,
-  "badBlocks": null,
+  "badBlocks": [
+    "0xea13975b16a70fb9727a7c0238920bc0df7c0c0bea0723af74ba6e41cccba299"
+  ],
   "lightSyncState": null,
   "codeSubstitutes": {},
   "genesis": {


### PR DESCRIPTION
This is to prevent validators from syncing immediately to the latest blocks after we have reverted them. This shouldn't be needed long-term (since we'll eventually build a bigger chain after the fix).