### PR TITLE
Make the override compatible with latest format for the chainspec

### DIFF
--- a/versi/parachain/overrides/stps-funded-accounts.json
+++ b/versi/parachain/overrides/stps-funded-accounts.json
@@ -1,6 +1,6 @@
 {
     "genesis": {
-      "runtime": {
+      "runtimeGenesis": {
         "balances": {
             "balances": [
             [


### PR DESCRIPTION
That was introduced in
https://github.com/paritytech/polkadot-sdk/pull/1256.

Without this fix updating the chain_spec pod in versi fails with:
```
+ BOOTNODES='"bootNodes": ["/dns/versi-tick-501-alice-node-0/tcp/30334/p2p/12D3KooWBsK6fux5wY2QqmNhE5HwfRVZiWFTL1T51XeBuE8op49t","/dns/versi-tick-501-bob-node-0/tcp/30334/p2p/12D3KooWMD4MDy2Vks4ErjTDaN6xb1P1Q5i5XTv5S3p1sj81tKzd"],'+ sed 's;"bootNodes.*;"bootNodes": ["/dns/versi-tick-501-alice-node-0/tcp/30334/p2p/12D3KooWBsK6fux5wY2QqmNhE5HwfRVZiWFTL1T51XeBuE8op49t","/dns/versi-tick-501-bob-node-0/tcp/30334/p2p/12D3KooWMD4MDy2Vks4ErjTDaN6xb1P1Q5i5XTv5S3p1sj81tKzd"],;' -i /dir/tick-dev-plain-01.json+ 


/usr/local/bin/polkadot-parachain build-spec --chain /dir/tick-dev-plain-01.json --rawError: Service(Other("Error parsing spec file: expected value at line 40 column 5"))
```