### PR TITLE
adding stkd bootnode to paseo-passet-hub

### DIFF
--- a/paseo/parachain/passet-hub/chainspec.json
+++ b/paseo/parachain/passet-hub/chainspec.json
@@ -1,6 +1,7 @@
 {
   "bootNodes": [
-    "/dns/paseo-passet-hub-collator-node-0.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWRYpkLtt6YyvkZKiG2st1oPAgivi3ZfeSRk1w53PjyzwP"
+    "/dns/paseo-passet-hub-collator-node-0.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWRYpkLtt6YyvkZKiG2st1oPAgivi3ZfeSRk1w53PjyzwP",
+    "/dns/passet-hub-paseo-01.bootnode.stkd.io/tcp/30633/wss/p2p/12D3KooWNNyKc92XgC9s56XxEVffMKAbdwXWVhmyUwjvcKHt34Ji"
   ],
   "chainType": "Live",
   "codeSubstitutes": {},


### PR DESCRIPTION
Hey, adding a bootnode from stkd for passet-hub. Node is located in Chile. Should be able to confirm connectivity with:

```
wget -O passet-hub.json https://raw.githubusercontent.com/sudo-whodo/chainspecs/refs/heads/main/paseo/parachain/passet-hub/chainspec.json

docker run -it \                                                                                                                         
  -v $(pwd)/passet-hub.json:/chainSpec.json \
  --platform=linux/amd64 \
  --rm parity/polkadot-parachain \
  --chain /chainSpec.json \
  --reserved-only \
  --reserved-nodes "/dns/passet-hub-paseo-01.bootnode.stkd.io/tcp/30633/wss/p2p/12D3KooWNNyKc92XgC9s56XxEVffMKAbdwXWVhmyUwjvcKHt34Ji"
```