### PR TITLE
Enable telemetry for Bulletin Chain (Westend + Paseo)

### DIFF
--- a/paseo/parachain/bulletin/chainspec.json
+++ b/paseo/parachain/bulletin/chainspec.json
@@ -6,7 +6,7 @@
     "/dns/paseo-bulletin-collator-node-0.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWRuKisocQ2Z5hBZagV5YGxJMYuW13xT42sUiUCWf5bRtu",
     "/dns/paseo-bulletin-collator-node-1.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWSgdX2egCUiXtDUNV6hGh6JrtTb9vQ6iRfFMdnTemQDDp"
   ],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [["wss://telemetry.polkadot.io/submit/", 0]],
   "protocolId": null,
   "properties": {
     "tokenDecimals": 10,

--- a/westend/parachain/bulletin/chainspec.json
+++ b/westend/parachain/bulletin/chainspec.json
@@ -6,7 +6,7 @@
     "/dns/westend-bulletin-collator-node-0.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWSxYQRoTT9rZNZRrjCfG2fPpBwPumkQsxLroTKjX6Mvkw",
     "/dns/westend-bulletin-collator-node-1.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWSD5tovFkmja9aFYA6QM8eU3mFhZKdAuCsa5MgSsNDmxc"
   ],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [["wss://telemetry.polkadot.io/submit/", 0]],
   "protocolId": null,
   "properties": {
     "tokenDecimals": 12,


### PR DESCRIPTION
Bulletin chain specs have `telemetryEndpoints: null`. Nodes only report to telemetry.polkadot.io if operators manually pass `--telemetry-url`.

This sets the endpoint in the chain spec itself (verbosity 0). Polkadot, Kusama and Westend relay chains do the same. Every node reports by default. "Westend Bulletin" and "Paseo Bulletin" show up on telemetry.polkadot.io automatically. Operators can opt out with `--no-telemetry`.

**Why not rely on `--telemetry-url` CLI flag?** It makes telemetry opt-in rather than opt-out, so we can't guarantee full network coverage.

**Why telemetry and not just Prometheus?** Prometheus is per-node (you scrape individual endpoints for deep diagnostics). Telemetry is network-wide (nodes push to a central server) — it answers "how many nodes are online, are they all producing blocks, what versions are they running?" without needing access to each node's metrics port.