### PR TITLE
Clean up leftover submodules/watr references

### DIFF
--- a/polkadot/parachain/watr/chainspec.json
+++ b/polkadot/parachain/watr/chainspec.json
@@ -1,1 +1,0 @@
-../../../submodules/watr/chain-specs/mainnet-raw.json


### PR DESCRIPTION
## Summary
- Delete the `submodules/watr` gitlink and the matching `polkadot/parachain/watr/chainspec.json` symlink

## Why
#1101 removed the `[submodule "submodules/watr"]` entry from `.gitmodules` (because the upstream `Watr-Protocol/watr.git` repo is no longer accessible) but left the `submodules/watr` gitlink in the tree and the symlink that pointed into it. The resulting inconsistency makes `actions/checkout` with `submodules: true` error out:

```
fatal: No url found for submodule path 'submodules/watr' in .gitmodules
```

This currently fails CI on every PR in the repo on every branch.
