### PR TITLE
paseo people next system: point /tcp/30333 bootnodes at dedicated p2p LB hostname

### DIFF
--- a/paseo/parachain/people-next-system/chainspec.json
+++ b/paseo/parachain/people-next-system/chainspec.json
@@ -1,8 +1,8 @@
 {
   "bootNodes": [
-    "/dns/paseo-people-next-system-collator-node-0.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWN5JKhxNAfij5EvbY2Kdr5oJvAVhL5WovmxaZ2Q6m69uP",
+    "/dns/paseo-people-next-system-collator-p2p-node-0.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWN5JKhxNAfij5EvbY2Kdr5oJvAVhL5WovmxaZ2Q6m69uP",
     "/dns/paseo-people-next-system-collator-node-0.parity-testnet.parity.io/tcp/443/wss/p2p/12D3KooWN5JKhxNAfij5EvbY2Kdr5oJvAVhL5WovmxaZ2Q6m69uP",
-    "/dns/paseo-people-next-system-collator-node-1.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWGboxsnnd1uqRUZUf3vL9fFgqnDvXxHtQ7LQN3YmPXhhY",
+    "/dns/paseo-people-next-system-collator-p2p-node-1.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWGboxsnnd1uqRUZUf3vL9fFgqnDvXxHtQ7LQN3YmPXhhY",
     "/dns/paseo-people-next-system-collator-node-1.parity-testnet.parity.io/tcp/443/wss/p2p/12D3KooWGboxsnnd1uqRUZUf3vL9fFgqnDvXxHtQ7LQN3YmPXhhY"
   ],
   "chainType": "Live",


### PR DESCRIPTION
Points the people-next-system `/tcp/30333` bootnodes at the collator LB's dedicated p2p hostname (`…-p2p-node-N`) so the raw-TCP transport is reachable for the native (rust) smoldot client; the `…-node-N` wss entries are unchanged.

Depends on paritytech/devops-cloud-infra#3858

Ref: paritytech/devops#5414