### PR TITLE
paseo asset-hub-next + bulletin-next: add /tcp/30333 collator bootnodes on dedicated p2p hostname

### DIFF
--- a/paseo/parachain/bulletin-next/chainspec.json
+++ b/paseo/parachain/bulletin-next/chainspec.json
@@ -1,6 +1,8 @@
 {
   "bootNodes": [
+    "/dns4/paseo-bulletin-next-collator-p2p-node-0.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWDGdPBWpytPdNAXDT2KJWwmPXkxvxyQLGc7pRdFWeZnyB",
     "/dns4/paseo-bulletin-next-collator-node-0.parity-testnet.parity.io/tcp/443/wss/p2p/12D3KooWDGdPBWpytPdNAXDT2KJWwmPXkxvxyQLGc7pRdFWeZnyB",
+    "/dns4/paseo-bulletin-next-collator-p2p-node-1.parity-testnet.parity.io/tcp/30333/p2p/12D3KooWC45NgktSLMPQafAhi8TMAtiiatnmNc3Qv6wA74u7YBVc",
     "/dns4/paseo-bulletin-next-collator-node-1.parity-testnet.parity.io/tcp/443/wss/p2p/12D3KooWC45NgktSLMPQafAhi8TMAtiiatnmNc3Qv6wA74u7YBVc",
     "/dns4/paseo-bulletin-next-rpc-node-0.polkadot.io/tcp/443/wss/p2p/12D3KooWS4ptBbHGritdb1T7JPxKT2EN7FXvqq9rUp12jUvjnqQ1",
     "/dns4/paseo-bulletin-next-rpc-node-1.polkadot.io/tcp/443/wss/p2p/12D3KooWKMc4jJsU7fdEsis4AsM8Assk5jFqhEUEa2ZSiWJGKpfv"


### PR DESCRIPTION
Adds raw-TCP `/tcp/30333` collator bootnodes. 

Depends on paritytech/devops-cloud-infra#3859.

Ref: paritytech/devops#5414